### PR TITLE
React 15.5 compatibility

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,9 +26,9 @@
     "jsdom-global": "^2.1.0",
     "mocha": "^3.2.0",
     "mocha-lcov-reporter": "^1.2.0",
-    "react": "^15.4.1",
-    "react-addons-test-utils": "^15.4.1",
-    "react-dom": "^15.4.1",
+    "react": "^15.5.4",
+    "react-dom": "^15.5.4",
+    "react-test-renderer": "^15.5.4",
     "sinon": "^1.17.6"
   },
   "babel": {

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,7 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 
-const PropTypes = {
+const propTypes = {
   completed: ((props, propName) => {
     if (typeof props[propName] !== 'number')
       return Progress.throwError('Invalid Props: "completed" should ∈ ℝ ');
@@ -8,11 +9,11 @@ const PropTypes = {
       return Progress.throwError('Invalid Props: "completed" should be between 0 and 100' );
     }
   }),
-  color: React.PropTypes.string,
-  animation: React.PropTypes.number,
-  height: React.PropTypes.oneOfType([
-    React.PropTypes.string,
-    React.PropTypes.number
+  color: PropTypes.string,
+  animation: PropTypes.number,
+  height: PropTypes.oneOfType([
+    PropTypes.string,
+    PropTypes.number
   ])
 };
 
@@ -42,7 +43,7 @@ class Progress extends React.Component {
   }
 };
 
-Progress.propTypes = PropTypes;
+Progress.propTypes = propTypes;
 Progress.throwError = function() {
   return new Error(...arguments);
 };


### PR DESCRIPTION
Provides React 15.5 compatibility. Imports PropTypes from prop-types instead of react and removes react-test-utils.